### PR TITLE
ArchiveUnpacker now preserves "executable" permissions in Tar and Zip

### DIFF
--- a/libs/unpuzzle-utils/src/main/groovy/org/akhikhl/unpuzzle/utils/ArchiveUnpacker.groovy
+++ b/libs/unpuzzle-utils/src/main/groovy/org/akhikhl/unpuzzle/utils/ArchiveUnpacker.groovy
@@ -13,13 +13,13 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
 import java.util.zip.GZIPInputStream
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
 
 import org.apache.commons.compress.archivers.ArchiveException
 import org.apache.commons.compress.archivers.ArchiveStreamFactory
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
 
@@ -112,9 +112,9 @@ final class ArchiveUnpacker {
 
   void unZip(final File inputFile, final File outputDir) throws IOException, ArchiveException {
     console.startProgress("Unzipping file: ${inputFile.getName()}")
-    ZipInputStream zis = new ZipInputStream(new FileInputStream(inputFile))
+    ZipArchiveInputStream zis = new ZipArchiveInputStream(new FileInputStream(inputFile))
     try {
-      ZipEntry ze = zis.getNextEntry()
+      ZipArchiveEntry ze = zis.getNextEntry()
       while (ze != null) {
         final File outputFile = new File(outputDir, ze.getName())
         console.info(ze.getName())

--- a/libs/unpuzzle-utils/src/test/groovy/org/akhikhl/unpuzzle/utils/ArchiveUnpackerTest.groovy
+++ b/libs/unpuzzle-utils/src/test/groovy/org/akhikhl/unpuzzle/utils/ArchiveUnpackerTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
  * Unit-test for {@link org.akhikhl.unpuzzle.utils.ArchiveUnpacker} class.
  * @author akhikhl
  */
-class ArchiveUnpackerTest {
+class ArchiveUnpackerTest extends Specification {
 
   static console
 
@@ -37,9 +37,9 @@ class ArchiveUnpackerTest {
     File[] unpackedFiles = testFolder.listFiles()
   then:
     unpackedFiles != null
-    unpackedFiles.length() == 1
+    unpackedFiles.length == 1
     unpackedFiles[0].name == 'sample.txt'
-    unpackedFiles[0].text == '0042bfe2-8812-11e3-85b6-6bf8a04179ee'
+    unpackedFiles[0].text == '0042bfe2-8812-11e3-85b6-6bf8a04179ee\n'
   }
 
   def 'should unpack .zip files'() {
@@ -49,9 +49,9 @@ class ArchiveUnpackerTest {
     File[] unpackedFiles = testFolder.listFiles()
   then:
     unpackedFiles != null
-    unpackedFiles.length() == 1
+    unpackedFiles.length == 1
     unpackedFiles[0].name == 'sample.txt'
-    unpackedFiles[0].text == '0042bfe2-8812-11e3-85b6-6bf8a04179ee'
+    unpackedFiles[0].text == '0042bfe2-8812-11e3-85b6-6bf8a04179ee\n'
   }
 }
 


### PR DESCRIPTION
When unpuzzle extracts the eclipse archives, it doesn't preserve the executable bits.  This means that if you want to use unpuzzle to install a runnable Eclipse, it doesn't work on Linux or Mac.  This PR fixes this issue.